### PR TITLE
Add react-context-connector.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@
 - [**unstated**](https://github.com/jamiebuilds/unstated) - A tiny dependency that provides a handy wrapper around the Context API for dependency injection.
 - [**react-storage-context**](https://github.com/giannif/react-storage-context) - Handy util for getting/setting local storage and session storage built on the Context API.
 - [**dakpan**](https://github.com/houfio/dakpan) - A small React state management library using the new React context.
+- [**react-context-connector**](https://github.com/BrOrlandi/react-context-connector) - React HOC to the new Context API to keep the use as simple as React-Redux connect HOC.
 
 ## Contribute
 


### PR DESCRIPTION
Hi, @diegohaz !
I have developed this lib to connect React new Context API Consumer with a HOC.
It's similar to the react-connect-context but mine allow a `mapContextToProps` function very like the `mapStateToProps` on React-Redux.
If you have any questions, please contact me!

Thanks!

PS: We already met once, at *Hackathon da Globo* in 2017.