### PR TITLE
add react-providers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@
 - [**react-storage-context**](https://github.com/giannif/react-storage-context) - Handy util for getting/setting local storage and session storage built on the Context API.
 - [**dakpan**](https://github.com/houfio/dakpan) - A small React state management library using the new React context.
 - [**react-context-connector**](https://github.com/BrOrlandi/react-context-connector) - React HOC to the new Context API to keep the use as simple as React-Redux connect HOC.
+- [**react-providers**](https://github.com/xnimorz/react-providers) - A small library that creates a centralized place to store (like Redux store) your context components and HOC to use it. Automatically resolves dependencies between your context components.
 
 ## Contribute
 


### PR DESCRIPTION
Hi, @diegohaz !
I have developed [react-providers](https://github.com/xnimorz/react-providers) to create a centralized place to store (like Redux store) your context components. This library provides a react.component `<AppProvider>` which allows to combine your context components and to resolve dependencies between them. So if BContext depends on AContext AppProvider will paste AContext above the BContext. 
To use context from AppProvider this library offers a HOC `use`.
I also added some examples of using this library (todoMVC example and components that have dependencies) https://xnimorz.github.io/react-providers/ 

If you have any questions, please contact me!

